### PR TITLE
fix Configure for gcc 14

### DIFF
--- a/Configure
+++ b/Configure
@@ -4097,6 +4097,7 @@ echo " "
 echo "Checking your choice of C compiler and flags for coherency..." >&4
 $cat > try.c <<'EOF'
 #include <stdio.h>
+#include <stdlib.h>
 main() { printf("Ok\n"); exit(0); }
 EOF
 set X $cc $optimize $ccflags -o try $ldflags try.c $libs
@@ -4304,6 +4305,7 @@ echo " "
 echo "Checking for GNU C Library..." >&4
 cat >gnulibc.c <<EOM
 #include <stdio.h>
+#include <stdlib.h>
 int
 main()
 {
@@ -5529,6 +5531,7 @@ case "$d_wifstat" in
 	$cat >foo.c <<EOCP
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <stdlib.h>
 
 main()
 {
@@ -6119,6 +6122,7 @@ $cat >try.c <<'EOCP'
 #ifdef I_SYSSELECT
 #include <sys/select.h>
 #endif
+#include <stdlib.h>
 main()
 {
 	struct tm foo;

--- a/Configure
+++ b/Configure
@@ -4098,7 +4098,7 @@ echo "Checking your choice of C compiler and flags for coherency..." >&4
 $cat > try.c <<'EOF'
 #include <stdio.h>
 #include <stdlib.h>
-main() { printf("Ok\n"); exit(0); }
+int main() { printf("Ok\n"); exit(0); }
 EOF
 set X $cc $optimize $ccflags -o try $ldflags try.c $libs
 shift

--- a/Configure
+++ b/Configure
@@ -3047,6 +3047,7 @@ echo " "
 echo "Checking for GNU cc in disguise and/or its version number..." >&4
 $cat >gccvers.c <<EOM
 #include <stdio.h>
+#include <stdlib.h>
 int main() {
 #ifdef __GNUC__
 #ifdef __VERSION__


### PR DESCRIPTION
Configure fails under gcc 14 because one of the tests within it, gccvers.c, is missing ```#include <stdlib.h>```.